### PR TITLE
Add LM Studio provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - deepseek
 > - xai
 > - groq
+> - lmstudio
 > - arceeai
 > - any other provider that is compatible with the OpenAI API
 >
@@ -473,6 +474,10 @@ export AZURE_OPENAI_API_VERSION="2025-03-01-preview" (Optional)
 
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key-here"
+
+# LM Studio
+export LMSTUDIO_API_KEY="your-lmstudio-key-here"
+export LMSTUDIO_BASE_URL="http://localhost:1234/v1" (Optional)
 
 # Similarly for other providers
 ```

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -50,6 +50,16 @@ env_key = "OPENAI_API_KEY"
 wire_api = "responses"
 ```
 
+LM Studio is also bundled with the following defaults:
+
+```toml
+[model_providers.lmstudio]
+name = "LM Studio"
+base_url = "http://localhost:1234/v1" # overridable via $LMSTUDIO_BASE_URL
+env_key = "LMSTUDIO_API_KEY"
+wire_api = "responses"
+```
+
 ## model_providers
 
 This option lets you override and amend the default set of model providers bundled with Codex. This value is a map where the key is the value to use with `model_provider` to select the correspodning provider.

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -13,6 +13,13 @@ use std::env::VarError;
 use crate::error::EnvVarError;
 use crate::openai_api_key::get_openai_api_key;
 
+/// Default base URL for the LM Studio local server.
+pub const DEFAULT_LMSTUDIO_BASE: &str = "http://localhost:1234/v1";
+
+fn env_or(var: &str, default: &str) -> String {
+    std::env::var(var).unwrap_or_else(|_| default.to_string())
+}
+
 /// Wire protocol that the provider speaks. Most third-party services only
 /// implement the classic OpenAI Chat Completions JSON schema, whereas OpenAI
 /// itself (and a handful of others) additionally expose the more modern
@@ -162,6 +169,16 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 env_key: Some("GROQ_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
+            },
+        ),
+        (
+            "lmstudio",
+            P {
+                name: "LM Studio".into(),
+                base_url: env_or("LMSTUDIO_BASE_URL", DEFAULT_LMSTUDIO_BASE),
+                env_key: Some("LMSTUDIO_API_KEY".into()),
+                env_key_instructions: None,
+                wire_api: WireApi::Responses,
             },
         ),
     ]


### PR DESCRIPTION
## Summary
- support LM Studio in built-in provider list
- expose defaults in config documentation
- document environment variables in README

## Testing
- `cargo fmt --all`
- `cargo test` *(fails: test failed in `codex-linux-sandbox` landlock)*

------
https://chatgpt.com/codex/tasks/task_e_68420bdba0148326b02350257689ad4f