### PR TITLE
Detect failed Landlock sandbox helper

### DIFF
--- a/codex-cli/src/utils/agent/sandbox/landlock.ts
+++ b/codex-cli/src/utils/agent/sandbox/landlock.ts
@@ -94,7 +94,7 @@ async function detectSandboxExecutable(): Promise<string> {
   return candidate;
 }
 
-const ERROR_WHEN_LANDLOCK_NOT_SUPPORTED = `\
+export const ERROR_WHEN_LANDLOCK_NOT_SUPPORTED = `\
 The combination of seccomp/landlock that Codex uses for sandboxing is not
 supported in this environment.
 
@@ -157,6 +157,15 @@ function getSandboxExecutable(): Promise<string> {
   }
 
   return sandboxExecutablePromise;
+}
+
+/**
+ * Verify that the Landlock helper exists and is functional in this
+ * environment. Intended for upfront checks before attempting to
+ * use the sandbox.
+ */
+export async function ensureLandlockSupported(): Promise<void> {
+  await getSandboxExecutable();
 }
 
 /** @return name of the native executable to use for Linux sandboxing. */

--- a/codex-cli/tests/sandbox-landlock-check.test.ts
+++ b/codex-cli/tests/sandbox-landlock-check.test.ts
@@ -1,0 +1,55 @@
+import { test, expect, vi } from "vitest";
+
+// Mock approvals so handleExecCommand always runs in the sandbox
+vi.mock("../src/approvals.js", () => ({
+  __esModule: true,
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: true }) as any,
+  isSafeCommand: () => null,
+}));
+
+// Silence logger output
+vi.mock("../src/utils/logger/log.js", () => ({
+  __esModule: true,
+  log: () => {},
+  isLoggingEnabled: () => false,
+}));
+// Force getSandbox to think it is running on Linux and simulate a failing Landlock helper.
+vi.mock("../src/utils/agent/sandbox/landlock.js", async () => {
+  const actual = await vi.importActual<any>("../src/utils/agent/sandbox/landlock.js");
+  return {
+    __esModule: true,
+    ...actual,
+    ensureLandlockSupported: vi.fn(() => Promise.reject(new Error(actual.ERROR_WHEN_LANDLOCK_NOT_SUPPORTED))),
+  };
+});
+
+import { _testGetSandbox, handleExecCommand } from "../src/utils/agent/handle-exec-command.js";
+import { ERROR_WHEN_LANDLOCK_NOT_SUPPORTED } from "../src/utils/agent/sandbox/landlock.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(value: string) {
+  Object.defineProperty(process, "platform", { value });
+}
+
+// Unit style check for getSandbox()
+test("getSandbox throws helpful error when Landlock unsupported", async () => {
+  setPlatform("linux");
+  await expect(_testGetSandbox(true)).rejects.toThrow(ERROR_WHEN_LANDLOCK_NOT_SUPPORTED);
+  setPlatform(originalPlatform);
+});
+
+// Integration path through handleExecCommand
+
+test("handleExecCommand surfaces Landlock failure", async () => {
+  setPlatform("linux");
+  const execInput = { cmd: ["echo", "hi"], workdir: undefined, timeoutInMillis: 1000 } as any;
+  const config = { model: "any", instructions: "" } as any;
+  const policy = { mode: "auto" } as any;
+  const getConfirmation = async () => ({ review: "yes" }) as any;
+
+  await expect(
+    handleExecCommand(execInput, config, policy, [], getConfirmation)
+  ).rejects.toThrow(ERROR_WHEN_LANDLOCK_NOT_SUPPORTED);
+  setPlatform(originalPlatform);
+});


### PR DESCRIPTION
## Summary
- export `ensureLandlockSupported` and error constant from Landlock helper
- check Landlock helper in `getSandbox()` and throw helpful error if unavailable
- expose `getSandbox` for testing
- add tests to simulate missing Landlock support

## Testing
- `pnpm test` *(fails: Test Files  2 failed | 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68485512f16883269e5cd3599f263c3b