### PR TITLE
Validate MCP names

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "rand 0.9.1",
+ "regex-lite",
  "reqwest",
  "seccompiler",
  "serde",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -51,6 +51,7 @@ tree-sitter = "0.25.3"
 tree-sitter-bash = "0.23.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 wildmatch = "2.4.0"
+regex-lite = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4.1"


### PR DESCRIPTION
## Summary
- validate MCP server names when spawning connections
- skip invalid tools during tool aggregation
- add tests covering invalid names and collisions
- use regex-lite in codex-core

## Testing
- `cargo test -p codex-core mcp_connection_manager -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_684854fc02e48326be81fbcbdf4b18ab