### PR TITLE
Add patch path tracking

### DIFF
--- a/codex-cli/src/utils/agent/apply-patch.ts
+++ b/codex-cli/src/utils/agent/apply-patch.ts
@@ -591,6 +591,23 @@ export function identify_files_added(text: string): Array<string> {
   return [...result];
 }
 
+export function identify_files_touched(text: string): Array<string> {
+  const lines = text.trim().split("\n");
+  const result = new Set<string>();
+  for (const line of lines) {
+    if (line.startsWith(UPDATE_FILE_PREFIX)) {
+      result.add(line.slice(UPDATE_FILE_PREFIX.length));
+    } else if (line.startsWith(DELETE_FILE_PREFIX)) {
+      result.add(line.slice(DELETE_FILE_PREFIX.length));
+    } else if (line.startsWith(ADD_FILE_PREFIX)) {
+      result.add(line.slice(ADD_FILE_PREFIX.length));
+    } else if (line.startsWith(MOVE_FILE_TO_PREFIX)) {
+      result.add(line.slice(MOVE_FILE_TO_PREFIX.length));
+    }
+  }
+  return [...result];
+}
+
 function _get_updated_file(
   text: string,
   action: PatchAction,

--- a/codex-cli/tests/apply-patch.test.ts
+++ b/codex-cli/tests/apply-patch.test.ts
@@ -5,6 +5,7 @@ import {
   DiffError,
   identify_files_added,
   identify_files_needed,
+  identify_files_touched,
   load_files,
   patch_to_commit,
   process_patch,
@@ -122,6 +123,19 @@ test("identify_files_needed & identify_files_added", () => {
     ["a.txt", "b.txt"].sort(),
   );
   expect(identify_files_added(patch)).toEqual(["c.txt"]);
+});
+
+test("identify_files_touched", () => {
+  const patch = `*** Begin Patch
+*** Update File: a.txt
+*** Move to: d.txt
+*** Delete File: b.txt
+*** Add File: c.txt
+*** End Patch`;
+
+  expect(new Set(identify_files_touched(patch))).toEqual(
+    new Set(["a.txt", "d.txt", "b.txt", "c.txt"]),
+  );
 });
 
 test("process_patch - update file with multiple chunks", () => {

--- a/codex-rs/apply-patch/apply_patch_tool_instructions.md
+++ b/codex-rs/apply-patch/apply_patch_tool_instructions.md
@@ -38,3 +38,4 @@ Note, then, that we do not use line numbers in this diff format, as the context 
 ```
 
 File references can only be relative, NEVER ABSOLUTE. After the apply_patch command is run, it will always say "Done!", regardless of whether the patch was successfully applied or not. However, you can determine if there are issue and errors by looking at any warnings or logging lines printed BEFORE the "Done!" is output.
+The CLI also extracts all file paths referenced in the patch, using them to validate that edits stay within allowed writable directories.


### PR DESCRIPTION
## Summary
- extend `ApplyPatchCommand` with `paths`
- track touched files when parsing patches
- use the collected paths during approval checks
- document new behaviour
- test `identify_files_touched`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684854f90c388326bdc2fd0f48b6f58f